### PR TITLE
fix: change link to absolute path for read more in post item

### DIFF
--- a/components/post-item.tsx
+++ b/components/post-item.tsx
@@ -41,7 +41,7 @@ export function PostItem({
           </dd>
         </dl>
         <Link
-          href={slug}
+          href={"/" + slug}
           className={cn(buttonVariants({ variant: "link" }), "py-0")}
         >
           Read more →


### PR DESCRIPTION
under tags page, relative path gets wrong url for post causes 404, change that to absolute path