### PR TITLE
Hide post and Tag when published is set to false

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -51,13 +51,15 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
                 const { slug, date, title, description, tags } = post;
                 return (
                   <li key={slug}>
-                    <PostItem
-                      slug={slug}
-                      date={date}
-                      title={title}
-                      description={description}
-                      tags={tags}
-                    />
+                    {post.published && (
+                      <PostItem
+                        slug={slug}
+                        date={date}
+                        title={title}
+                        description={description}
+                        tags={tags}
+                      />
+                    )}
                   </li>
                 );
               })}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,15 +45,17 @@ export default function Home() {
         </h2>
         <ul className="flex flex-col">
           {latestPosts.map((post) => (
-            <li key={post.slug} className="first:border-t first:border-border">
-              <PostItem
-                slug={post.slug}
-                title={post.title}
-                description={post.description}
-                date={post.date}
-                tags={post.tags}
-              />
-            </li>
+            post.published && (
+              <li key={post.slug} className="first:border-t first:border-border">
+                <PostItem
+                  slug={post.slug}
+                  title={post.title}
+                  description={post.description}
+                  date={post.date}
+                  tags={post.tags}
+                />
+              </li>
+            )
           ))}
         </ul>
       </section>

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -54,13 +54,15 @@ export default function TagPage({ params }: TagPageProps) {
                 const { slug, date, title, description, tags } = post;
                 return (
                   <li key={slug}>
-                    <PostItem
-                      slug={slug}
-                      date={date}
-                      title={title}
-                      description={description}
-                      tags={tags}
-                    />
+                    {post.published && (
+                      <PostItem
+                        slug={slug}
+                        date={date}
+                        title={title}
+                        description={description}
+                        tags={tags}
+                      />
+                    )}
                   </li>
                 );
               })}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -27,9 +27,11 @@ export function sortPosts(posts: Array<Post>) {
 export function getAllTags(posts: Array<Post>) {
   const tags: Record<string, number> = {}
   posts.forEach(post => {
-    post.tags?.forEach(tag => {
-      tags[tag] = (tags[tag] ?? 0) + 1;
-    })
+    if (post.published) {
+      post.tags?.forEach(tag => {
+        tags[tag] = (tags[tag] ?? 0) + 1;
+      })
+    }
   })
 
   return tags;

--- a/managed_context/metadata.json
+++ b/managed_context/metadata.json
@@ -1,0 +1,1 @@
+{"current_schema_version":"0.0.1"}

--- a/test_suite_analysis/metadata.json
+++ b/test_suite_analysis/metadata.json
@@ -1,0 +1,1 @@
+{"current_schema_version":"0.0.1"}


### PR DESCRIPTION
**Description:**

Since the implementation of the ability to publish and unpublish posts, it is now essential to ensure that only published posts are displayed to users. This pull request addresses this requirement by adding a condition to the mapping function that renders the list of posts. This condition checks if each post is published before rendering it. If a post is unpublished, it will be excluded from the list.

**Changes Made:**

- Added a condition to the mapping function that renders the list of posts.
- The condition checks if each post is published (`post.published`) before rendering it.
- If a post is unpublished (`post.published`), it is excluded from the list.